### PR TITLE
fix: Others 카테고리 추가에 맞춰 범례 박스 확장

### DIFF
--- a/src/utils/generateCategorySvg.ts
+++ b/src/utils/generateCategorySvg.ts
@@ -43,8 +43,8 @@ export function generateCategorySvg(stats: TCategoryStats, theme: Theme = 'light
   let currentAngle = 0;
 
   const legendStartX = 25;
-  const legendStartY = 75;
-  const legendItemHeight = 22;
+  const legendStartY = 64;
+  const legendItemHeight = 23;
   const maxLegendItems = 5;
 
   // 카테고리가 없는 경우
@@ -140,7 +140,7 @@ export function generateCategorySvg(stats: TCategoryStats, theme: Theme = 'light
   <text x="20" y="30" class="title">Most Solved Categories</text>
 
   <!-- 범례 배경 -->
-  <rect x="15" y="55" width="175" height="120" fill="${colors.cardBackground}" rx="8" ry="8"/>
+  <rect x="15" y="50" width="175" height="130" fill="${colors.cardBackground}" rx="8" ry="8"/>
 
   <!-- 범례 -->
   <g transform="translate(0, 0)">


### PR DESCRIPTION
## 배경
Dreamhack API에 `others` 카테고리가 새로 추가되면서 **Most Solved Categories** 범례 항목이 4개 → 5개로 늘었습니다. 그 결과 기존 4개 기준으로 잡혀 있던 범례 배경 박스가 5개를 담기엔 하단이 빡빡해져, 맨 아래 항목이 박스 경계에 거의 붙어 보이는 문제가 있었습니다.

## 변경 사항
`src/utils/generateCategorySvg.ts` 범례 레이아웃 조정:

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| 범례 시작점 `legendStartY` | 75 | 64 |
| 항목 간격 `legendItemHeight` | 22 | 23 |
| 배경 박스 `y` | 55 | 50 |
| 배경 박스 `height` | 120 | 130 |

- 박스를 위로 올리고 키워 5개 항목의 상·하단 여백을 각 14px로 균형 있게 맞춤
- SVG 전체 크기(390×190)는 그대로 유지 → README 레이아웃 영향 없음

## 테스트
- `generateCategorySvg.test.ts` 6개 전부 통과 (좌표값을 검증하지 않아 영향 없음)
- dev 서버에서 실제 데이터로 렌더링 확인 (5개 항목이 박스 안에 균형 있게 배치됨)